### PR TITLE
Fix floating point arithmetic errors

### DIFF
--- a/src/3D/Bin.js
+++ b/src/3D/Bin.js
@@ -1,3 +1,5 @@
+import { factoredInteger } from './util';
+
 export default class Bin {
 
   name = '';
@@ -8,12 +10,12 @@ export default class Bin {
 
   items = [];
 
-  constructor(name, w, h, d, mw) {
+  constructor(name, w, h, d, mw, p = 3) {
     this.name = name;
-    this.width = w;
-    this.height = h;
-    this.depth = d;
-    this.maxWeight = mw;
+    this.width = factoredInteger( w, p );
+    this.height = factoredInteger( h, p );
+    this.depth = factoredInteger( d, p );
+    this.maxWeight = factoredInteger( mw, p );
   }
 
   getName() {

--- a/src/3D/Bin.js
+++ b/src/3D/Bin.js
@@ -10,12 +10,12 @@ export default class Bin {
 
   items = [];
 
-  constructor(name, w, h, d, mw, p = 3) {
+  constructor(name, w, h, d, mw) {
     this.name = name;
-    this.width = factoredInteger( w, p );
-    this.height = factoredInteger( h, p );
-    this.depth = factoredInteger( d, p );
-    this.maxWeight = factoredInteger( mw, p );
+    this.width = factoredInteger( w );
+    this.height = factoredInteger( h );
+    this.depth = factoredInteger( d );
+    this.maxWeight = factoredInteger( mw );
   }
 
   getName() {

--- a/src/3D/Item.js
+++ b/src/3D/Item.js
@@ -33,12 +33,12 @@ export default class Item {
   rotationType = RotationType_WHD;
   position = []; // x, y, z
 
-  constructor(name, w, h, d, wg, p = 3) {
+  constructor(name, w, h, d, wg) {
     this.name = name;
-    this.width = factoredInteger( w, p );
-    this.height = factoredInteger( h, p );
-    this.depth = factoredInteger( d, p );
-    this.weight = factoredInteger( wg, p );
+    this.width = factoredInteger( w );
+    this.height = factoredInteger( h );
+    this.depth = factoredInteger( d );
+    this.weight = factoredInteger( wg );
   }
 
   getWidth() {

--- a/src/3D/Item.js
+++ b/src/3D/Item.js
@@ -1,3 +1,5 @@
+import { factoredInteger } from './util';
+
 export const RotationType_WHD = 0;
 export const RotationType_HWD = 1;
 export const RotationType_HDW = 2;
@@ -31,12 +33,12 @@ export default class Item {
   rotationType = RotationType_WHD;
   position = []; // x, y, z
 
-  constructor(name, w, h, d, wg) {
+  constructor(name, w, h, d, wg, p = 3) {
     this.name = name;
-    this.width = w;
-    this.height = h;
-    this.depth = d;
-    this.weight = wg;
+    this.width = factoredInteger( w, p );
+    this.height = factoredInteger( h, p );
+    this.depth = factoredInteger( d, p );
+    this.weight = factoredInteger( wg, p );
   }
 
   getWidth() {

--- a/src/3D/util.js
+++ b/src/3D/util.js
@@ -1,0 +1,6 @@
+/**
+ * Factor a number by the given value and round to the nearest whole number
+ */
+export const factoredInteger = ( value, factor ) => (
+    Math.round( value * ( 10 ** factor ) )
+);

--- a/src/3D/util.js
+++ b/src/3D/util.js
@@ -1,6 +1,11 @@
 /**
- * Factor a number by the given value and round to the nearest whole number
+ * Precision to retain in factoredInteger()
  */
-export const factoredInteger = ( value, factor ) => (
-    Math.round( value * ( 10 ** factor ) )
+const FACTOR = 5;
+
+/**
+ * Factor a number by FACTOR and round to the nearest whole number
+ */
+export const factoredInteger = ( value ) => (
+    Math.round( value * ( 10 ** FACTOR ) )
 );

--- a/test/3DTest.js
+++ b/test/3DTest.js
@@ -108,6 +108,21 @@ const testDatas = [
       return packer.bins[0].items.length === 2
         && packer.unfitItems.length === 1;
     }
+  },
+  {
+    // https://github.com/Automattic/woocommerce-services/issues/1293
+    name: 'Floating point arithmetic is handled correctly.',
+    bins: [
+      new Bin("Bin 1", 12, 12, 5.5, 70),
+    ],
+    items: [
+      new Item("Item 1", 12, 12, .005, .0375),
+      new Item("Item 2", 12, 12, .005, .0375),
+    ],
+    expectation: function (packer) {
+      return packer.bins[0].items.length === 2
+        && packer.unfitItems.length === 0;
+    }
   }
 ];
 

--- a/test/util.js
+++ b/test/util.js
@@ -1,0 +1,12 @@
+import { factoredInteger } from '../src/3D/util';
+const assert = require('assert');
+
+describe('util.js', function() {
+    it('factoredInteger()', function () {
+        assert.strictEqual( factoredInteger( 1 ), 100000 );
+        assert.strictEqual( factoredInteger( 123 ), 12300000 );
+        assert.strictEqual( factoredInteger( .00001 ), 1 );
+        assert.strictEqual( factoredInteger( .123456 ), 12346 );
+        assert.strictEqual( factoredInteger( .123454 ), 12345 );
+    });
+});


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-services/issues/1293.

To test:
* Review new test case
* `npm run dev`
* `npm test`

Represent `Bin` and `Item` dimensions as rounded integers after multiplying by a factor of 10.

Before this fix, item collision detect fell prey to situations like:

```javascript
Math.max( .0025, .0075 ) - Math.min( .0025, .0075 )
0.004999999999999999
```

This caused false positive collisions in `rectIntersect()`.