### PR TITLE
Fix rotation with multiple items

### DIFF
--- a/src/3D/Bin.js
+++ b/src/3D/Bin.js
@@ -78,9 +78,8 @@ export default class Bin {
 
       if (fit) {
         box.items.push(item);
+        return fit;
       }
-
-      return fit;
     }
 
     return fit;

--- a/src/3D/Packer.js
+++ b/src/3D/Packer.js
@@ -83,15 +83,16 @@ export default class Packer {
           for (let _j=0; _j < b.items.length; _j++) {
             let pv;
             let ib = b.items[_j];
+            let d = ib.getDimension();
             switch (_pt) {
               case WidthAxis:
-                pv = [ib.position[0] + ib.getWidth(), ib.position[1], ib.position[2]];
+                pv = [ib.position[0] + d[0], ib.position[1], ib.position[2]];
                 break;
               case HeightAxis:
-                pv = [ib.position[0], ib.position[1] + ib.getHeight(), ib.position[2]];
+                pv = [ib.position[0], ib.position[1] + d[1], ib.position[2]];
                 break;
               case DepthAxis:
-                pv = [ib.position[0], ib.position[1], ib.position[2] + ib.getDepth()];
+                pv = [ib.position[0], ib.position[1], ib.position[2] + d[2]];
                 break;
             }
 

--- a/test/3DTest.js
+++ b/test/3DTest.js
@@ -22,15 +22,15 @@ const testDatas = [
     }
   },
   {
-    name: 'Test three items fit into smaller bin.',
+    name: 'Test three items fit into smaller bin after being rotated.',
     bins: [
       new Bin("1. Le petite box", 296, 296, 8, 1000),
       new Bin("2. Le grande box", 2960, 2960, 80, 10000),
     ],
     items: [
       new Item("Item 1", 250, 250, 2, 200),
-      new Item("Item 2", 250, 250, 2, 200),
-      new Item("Item 3", 250, 250, 2, 200),
+      new Item("Item 2", 250, 2, 250, 200),
+      new Item("Item 3", 2, 250, 250, 200),
     ],
     expectation: function (packer) {
       return packer.bins[0].name === '1. Le petite box'


### PR DESCRIPTION
* Fix return in `Bin::putItem()` that prevented item rotations after an intersection occurred.
* Use the rotated dimension value when testing different item pivots.
